### PR TITLE
removes forward spaces from numeric selector

### DIFF
--- a/grammars/html (liquid).cson
+++ b/grammars/html (liquid).cson
@@ -134,7 +134,7 @@
         'name': 'string.quoted.single.liquid'
       }
       {
-        'match': '(-|\\+)?\\s*[0-9]+(\\.[0-9]+)?'
+        'match': '([-+]?[0-9]+(\\.[0-9]+)?)'
         'name': 'constant.numeric.liquid'
       }
       {


### PR DESCRIPTION
I fixed match to remove forward spaces from numeric selector. This is useful for themes like [mine](https://github.com/biletskyy/flatwhite-syntax) with color background highlights.
