### PR TITLE
removes leading whitespace form .tag selector

### DIFF
--- a/grammars/html (liquid).cson
+++ b/grammars/html (liquid).cson
@@ -63,8 +63,10 @@
   'template_tag_name':
     'patterns': [
       {
-        'match': '(?<={%)\\s*(\\w+)'
-        'name': 'entity.name.tag.liquid'
+        'captures':
+          '2':
+            'name': 'entity.name.tag.liquid'
+        'match': '((?<={%)\\s*(\\w+))'
       }
     ]
   'template_var':


### PR DESCRIPTION
I fixed `template_tag_name` pattern to capture just tag word itself without leading whitespace.
