### PR TITLE
Grammar for highlighting changes to snippets in PR #21

### DIFF
--- a/grammars/html (liquid).cson
+++ b/grammars/html (liquid).cson
@@ -7,13 +7,13 @@
 'name': 'HTML (Liquid)'
 'patterns': [
   {
-    'begin': '{%\\s*comment\\s*%}'
-    'end': '{%\\s*endcomment\\s*%}'
+    'begin': '({%-*)\\s*comment\\s(-*%})'
+    'end': '({%-*)\\s*endcomment\\s(-*%})'
     'name': 'comment.block.liquid'
   }
   {
-    'begin': '{{'
-    'end': '}}'
+    'begin': '({{-*)'
+    'end': '(-*}})'
     'name': 'punctuation.output.liquid'
     'patterns': [
       {
@@ -22,8 +22,8 @@
     ]
   }
   {
-    'begin': '{%'
-    'end': '%}'
+    'begin': '({%-*)'
+    'end': '(-*%})'
     'name': 'punctuation.tag.liquid'
     'patterns': [
       {


### PR DESCRIPTION
@puranjayjain this is my attempt at the grammar file for correctly highlight the whitespace-controlling characters that the snippets now use — re: https://github.com/puranjayjain/language-liquid/pull/21 — BUT I don’t think it is working fully, can you check it out for me?

re: https://github.com/puranjayjain/language-liquid/issues/20