### PR TITLE
Removes whitespace in {% if condition ... snippet

### DIFF
--- a/snippets/language-liquid.cson
+++ b/snippets/language-liquid.cson
@@ -16,7 +16,7 @@
     'body': '{%- for ${1:element} in ${2:collection} -%}\n\t${3}\n{%- endfor -%}'
   'if...else...':
     'prefix': 'lif'
-    'body': '{%- if  ${1:condition} -%}\n  ${2:what to do}\n{%- else -%}\n  ${3:what to do else}\n{%- endif -%}\n'
+    'body': '{%- if ${1:condition} -%}\n  ${2:what to do}\n{%- else -%}\n  ${3:what to do else}\n{%- endif -%}\n'
   'include':
     'prefix': 'lin'
     'body': '{%- include ${1:include}.html -%}'


### PR DESCRIPTION
Prevents this from happening:
<img width="216" alt="screen shot 2016-11-30 at 22 41 30" src="https://cloud.githubusercontent.com/assets/486590/20784290/2d1d82a4-b74e-11e6-8969-cac22090c0cc.png">
