### PR TITLE
Makes all snippets available in GFM and HTML(Liquid)

### DIFF
--- a/snippets/language-liquid.cson
+++ b/snippets/language-liquid.cson
@@ -1,4 +1,4 @@
-'.text.html.liquid':
+'.text.html.liquid, source.gfm':
   'block':
     'prefix': '%'
     'body': '{%- ${1} -%}'
@@ -27,7 +27,7 @@
     'prefix': 'lcw'
     'body': '{%- when \'${1:matching?}\' %}\n\t${2:what to do} \n'
 # this covers everything (almost) from https://shopify.github.io/liquid/
-'.source.gfm':
+'.source.gfm, .text.html.liquid':
   # Basics > Introduction
   'Objects':
     'prefix': '{{'


### PR DESCRIPTION
Most of the snippets are only available from Markdown, not sure why this is—I prefer to have all the snippets available from both Markdown and HTML(Liquid) files. Perhaps I'm missing something obvious, but after expanding the sources I find the snippets a lot more useful.