### PR TITLE
Remove Jekyll sort filter (duplicate key)

### DIFF
--- a/snippets/language-liquid.cson
+++ b/snippets/language-liquid.cson
@@ -506,11 +506,6 @@
     'body': 'jsonify'
     'description': 'Convert Hash or Array to JSON.'
     'descriptionMoreURL': 'https://jekyllrb.com/docs/templates/'
-  'sort':
-    'prefix': 'sort'
-    'body': 'sort'
-    'description': 'Sort an array. Optional arguments for hashes: 1. property name 2. nils order (first or last).'
-    'descriptionMoreURL': 'https://jekyllrb.com/docs/templates/'
   'sample':
     'prefix': 'sample'
     'body': 'sample'


### PR DESCRIPTION
Removed the Jekyll sort key from the snippets file, as having duplicate keys is causing the snippets file not to load. The original sort filter key from Shopify remains.
